### PR TITLE
Update import path for Callable to work with python 3.9+

### DIFF
--- a/django_xmlrpc/registry.py
+++ b/django_xmlrpc/registry.py
@@ -37,7 +37,10 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-from collections import Callable
+try:
+    from collections import Callable
+except ImportError:
+    from collections.abc import Callable
 from logging import getLogger
 
 from django.apps import apps


### PR DESCRIPTION
Eerste stap voor opwerken naar Python 3.12